### PR TITLE
Reorder Makefile flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: all clean
 
 bin/%.o: src/%.c
-	gcc -Wall -Wpedantic -Wextra `pkg-config --cflags gtk+-3.0` -c $< -o $@
+	gcc -Wall -Wpedantic -Wextra -c $< -o $@ `pkg-config --cflags gtk+-3.0`
 
 bin/phondue: $(patsubst src/%.c, bin/%.o, $(wildcard src/*.c))
-	gcc -Wall -Wpedantic -Wextra `pkg-config --libs gtk+-3.0` $^ -o $@
+	gcc -Wall -Wpedantic -Wextra $^ -o $@ `pkg-config --libs gtk+-3.0`
 
 all: bin/phondue
 


### PR DESCRIPTION
`gcc` couldn't compile this properly until the flags were in the right order, see [this StackOverflow post](https://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc).